### PR TITLE
Allow '-' and '_' characters in argument keys, as well as A-Z, a-z, and '.'

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -770,7 +770,7 @@ window.html10n = (function(window, document, undefined) {
   // replace {{arguments}} with their values or the
   // associated translation string (based on its key)
   function substArguments(str, args) {
-    var reArgs = /\{\{\s*([a-zA-Z\.]+)\s*\}\}/
+    var reArgs = /\{\{\s*([a-zA-Z_\-\.]+)\s*\}\}/
       , match
     
     while (match = reArgs.exec(str)) {


### PR DESCRIPTION
Adding these characters improves the mapping from our literal to prepared text.

I'm depending on this for the current translations. We need to consider whether it's better to add to the acceptable characters set or adapt our substitution keys to accommodate the existing one. @devgeeks:
- The danger of extending the acceptable characters set is the possibility of averting others from adopting our changes, on the grounds that they might have matching literal text that is not meant to be treated as substitution arguments.
- This seems pretty unlikely though - it's the difference between:
  - `{{ZeroKnowledge}}` - currently accepted as a substitution string
  - `{{Zero-Knowledge}}` - not currently accepted, but will be with my change.
- I doubt that anyone would depend on that small a difference, or even by chance have strings that just happen to almost qualify.
- So I'm in favor of changing the acceptable set, hence this PR.
- Reject this PR if you feel otherwise, and we'll maintain more adjusted source translation strings, instead.
