### PR TITLE
Warn rather than crash on unsatisfied translation parameters.

### DIFF
--- a/l10n.js
+++ b/l10n.js
@@ -783,21 +783,23 @@ window.html10n = (function(window, document, undefined) {
   // replace {{arguments}} with their values or the
   // associated translation string (based on its key)
   function substArguments(str, args) {
-    var reArgs = /\{\{\s*([a-zA-Z_\-\.]+)\s*\}\}/
-      , match
-    
+    var reArgs = /\{\{\s*([a-zA-Z_\-\.]+)\s*\}\}/,
+        translations = html10n.translations,
+        match;
+
     while (match = reArgs.exec(str)) {
       if (!match || match.length < 2)
         return str // argument key not found
 
       var arg = match[1]
         , sub = ''
-      if (arg in args) {
+      if (args && (arg in args)) {
         sub = args[arg]
       } else if (arg in translations) {
         sub = translations[arg]
       } else {
-        consoleWarn('Could not find argument {{' + arg + '}}')
+        consoleWarn('Could not satisfy argument {{' + arg + '}}' +
+                    ' for string "' + str + '"');
         return str
       }
 


### PR DESCRIPTION
Prevent translation result strings that have parameters which are not satisfied by .get() arguments or existing translations from crashing the app.

The code that was supposed to do this was trying an 'in' of an undefined, which is a TypeError (in strict mode, at least).

There was another, crashing error in the followup code, reference to an undefined 'translations', also fixed.

(These kinds of errors would be trivially exposed by running in 'strict' mode, but getting that to happen is impeded greatly by the idiosyncratic layout. Gosh, this all harkens back to perl...)
